### PR TITLE
Fix deployment when Appwrite env vars are missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@ Kickstart your Next.js development with this ready-to-use starter project integr
 
 ## 🚀Getting started
 
-###
-Clone the Project
+### Clone the Project
 Clone this repository to your local machine using Git:
 
 `git clone https://github.com/appwrite/starter-for-nextjs`
 
-## 🛠️ Development guid
+## 🛠️ Development guide
 1. **Configure Appwrite**<br/>
    Navigate to `.env` and update the values to match your Appwrite project credentials.
+   When deploying to a platform like Vercel, ensure the `NEXT_PUBLIC_APPWRITE_ENDPOINT`
+   and `NEXT_PUBLIC_APPWRITE_PROJECT_ID` environment variables are available.
+   Otherwise the Appwrite client will only be partially initialised.
 2. **Customize as needed**<br/>
    Modify the starter kit to suit your app's requirements. Adjust UI, features, or backend
    integrations as per your needs.

--- a/src/lib/appwrite.js
+++ b/src/lib/appwrite.js
@@ -1,8 +1,22 @@
 import { Client, Account, Databases } from "appwrite";
 
-const client = new Client()
-  .setEndpoint(process.env.NEXT_PUBLIC_APPWRITE_ENDPOINT)
-  .setProject(process.env.NEXT_PUBLIC_APPWRITE_PROJECT_ID);
+const client = new Client();
+
+if (process.env.NEXT_PUBLIC_APPWRITE_ENDPOINT) {
+  client.setEndpoint(process.env.NEXT_PUBLIC_APPWRITE_ENDPOINT);
+} else {
+  console.warn(
+    "NEXT_PUBLIC_APPWRITE_ENDPOINT is not defined. Appwrite will not be fully initialised."
+  );
+}
+
+if (process.env.NEXT_PUBLIC_APPWRITE_PROJECT_ID) {
+  client.setProject(process.env.NEXT_PUBLIC_APPWRITE_PROJECT_ID);
+} else {
+  console.warn(
+    "NEXT_PUBLIC_APPWRITE_PROJECT_ID is not defined. Appwrite will not be fully initialised."
+  );
+}
 
 const account = new Account(client);
 const databases = new Databases(client);


### PR DESCRIPTION
## Summary
- guard Appwrite client initialization if env vars aren't provided
- clarify environment variables required for deployment in the README

## Testing
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68669d82f270832ab06fb69c26252e64