### PR TITLE
Enable TypeScript setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,3 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
-next-env.d.ts

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,7 +1,0 @@
-{
-  "compilerOptions": {
-    "paths": {
-      "@/*": ["./src/*"]
-    }
-  }
-}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,10 @@
       },
       "devDependencies": {
         "prettier": "3.5.3",
-        "prettier-plugin-tailwindcss": "^0.6.11"
+        "prettier-plugin-tailwindcss": "^0.6.11",
+        "typescript": "^5.4.5",
+        "@types/react": "^18.2.67",
+        "@types/node": "^18.19.21"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   },
   "devDependencies": {
     "prettier": "3.5.3",
-    "prettier-plugin-tailwindcss": "^0.6.11"
+    "prettier-plugin-tailwindcss": "^0.6.11",
+    "typescript": "^5.4.5",
+    "@types/react": "^18.2.67",
+    "@types/node": "^18.19.21"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.js"
+  ],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- install TypeScript type dependencies
- switch `jsconfig.json` to `tsconfig.json` with recommended options
- add `next-env.d.ts` for Next.js TypeScript support
- stop ignoring `next-env.d.ts`

## Testing
- `npm install --save-dev typescript @types/react @types/node` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d36dd7210832aaca1ef457ddceca6