### PR TITLE
Add authentication pages with Appwrite

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "../../lib/AuthProvider";
+
+export default function DashboardPage() {
+  const { user, logout } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (user === null) {
+      router.replace("/login");
+    }
+  }, [user, router]);
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center space-y-4">
+      <h1 className="text-2xl font-bold">Bienvenue {user.name}</h1>
+      <button
+        className="bg-orange-700 text-white px-4 py-2 rounded"
+        onClick={() => {
+          logout().then(() => router.push("/"));
+        }}
+      >
+        Se déconnecter
+      </button>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { ReactNode } from "react";
+import { AuthProvider } from "../lib/AuthProvider";
 
 export const metadata = {
   title: "Appwrite + Next.js",
@@ -24,7 +25,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
         <link rel="icon" type="image/svg+xml" href="/appwrite.svg" />
       </head>
       <body className={"bg-[#FAFAFB] font-[Inter] text-sm text-[#56565C]"}>
-        {children}
+        <AuthProvider>{children}</AuthProvider>
       </body>
     </html>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "../../lib/AuthProvider";
+
+export default function LoginPage() {
+  const { login } = useAuth();
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await login(email, password);
+      router.push("/dashboard");
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white p-6 rounded shadow w-full max-w-sm space-y-4"
+      >
+        <h1 className="text-xl font-bold text-center">Se connecter</h1>
+        {error && <p className="text-red-600">{error}</p>}
+        <input
+          type="email"
+          placeholder="Email"
+          className="border w-full p-2 rounded"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <input
+          type="password"
+          placeholder="Mot de passe"
+          className="border w-full p-2 rounded"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <button
+          type="submit"
+          className="w-full bg-orange-700 text-white p-2 rounded"
+        >
+          Connexion
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,17 +7,37 @@ import { client } from "../lib/appwrite";
 import { AppwriteException } from "appwrite";
 import Image from "next/image";
 import React from "react";
+import { useAuth } from "../lib/AuthProvider";
 
 export default function LandingPage() {
+  const { user, logout } = useAuth();
   return (
     <div className="min-h-screen flex flex-col bg-gradient-to-br from-orange-50 to-yellow-50">
       {/* Header */}
       <header className="flex justify-between items-center px-8 py-6 bg-white shadow">
         <div className="text-2xl font-bold text-orange-700">Spin Living</div>
-        <nav className="space-x-6">
+        <nav className="space-x-6 flex items-center">
           <a href="#how" className="text-gray-700 hover:text-orange-700">Comment ça marche</a>
           <a href="#avantages" className="text-gray-700 hover:text-orange-700">Avantages</a>
           <a href="#temoignages" className="text-gray-700 hover:text-orange-700">Témoignages</a>
+          {user ? (
+            <>
+              <a href="/dashboard" className="text-gray-700 hover:text-orange-700">Dashboard</a>
+              <button className="text-gray-700 hover:text-orange-700" onClick={() => logout()}>
+                Déconnexion
+              </button>
+            </>
+          ) : (
+            <>
+              <a href="/login" className="text-gray-700 hover:text-orange-700">Connexion</a>
+              <a
+                href="/signup"
+                className="bg-orange-700 text-white px-4 py-2 rounded hover:bg-orange-800"
+              >
+                Inscription
+              </a>
+            </>
+          )}
         </nav>
       </header>
 
@@ -103,3 +123,4 @@ export default function LandingPage() {
     </div>
   );
 }
+

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "../../lib/AuthProvider";
+
+export default function SignupPage() {
+  const { signup } = useAuth();
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await signup(email, password, name);
+      router.push("/dashboard");
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white p-6 rounded shadow w-full max-w-sm space-y-4"
+      >
+        <h1 className="text-xl font-bold text-center">Créer un compte</h1>
+        {error && <p className="text-red-600">{error}</p>}
+        <input
+          type="text"
+          placeholder="Nom"
+          className="border w-full p-2 rounded"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
+        <input
+          type="email"
+          placeholder="Email"
+          className="border w-full p-2 rounded"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <input
+          type="password"
+          placeholder="Mot de passe"
+          className="border w-full p-2 rounded"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <button
+          type="submit"
+          className="w-full bg-orange-700 text-white p-2 rounded"
+        >
+          Inscription
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/lib/AuthProvider.tsx
+++ b/src/lib/AuthProvider.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useState } from "react";
+import { Models } from "appwrite";
+import {
+  createAccount,
+  login as loginApi,
+  logout as logoutApi,
+  getCurrentAccount,
+} from "./auth";
+
+type AuthContextType = {
+  user: Models.User<Models.Preferences> | null;
+  login: (email: string, password: string) => Promise<void>;
+  signup: (email: string, password: string, name: string) => Promise<void>;
+  logout: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<Models.User<Models.Preferences> | null>(null);
+
+  const refreshUser = async () => {
+    const account = await getCurrentAccount();
+    setUser(account);
+  };
+
+  useEffect(() => {
+    refreshUser();
+  }, []);
+
+  const login = async (email: string, password: string) => {
+    await loginApi(email, password);
+    await refreshUser();
+  };
+
+  const signup = async (email: string, password: string, name: string) => {
+    await createAccount(email, password, name);
+    await refreshUser();
+  };
+
+  const logout = async () => {
+    await logoutApi();
+    setUser(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, login, signup, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,28 @@
+import { account } from "./appwrite";
+import { ID, Models } from "appwrite";
+
+export async function createAccount(email: string, password: string, name: string) {
+  await account.create(ID.unique(), email, password, name);
+  return login(email, password);
+}
+
+export async function login(email: string, password: string) {
+  await account.createEmailSession(email, password);
+  return getCurrentAccount();
+}
+
+export async function getCurrentAccount(): Promise<Models.User<Models.Preferences> | null> {
+  try {
+    return await account.get();
+  } catch (err) {
+    return null;
+  }
+}
+
+export async function logout() {
+  try {
+    await account.deleteSession("current");
+  } catch (err) {
+    console.error(err);
+  }
+}


### PR DESCRIPTION
## Summary
- add helper functions for Appwrite auth
- create React context provider for auth state
- protect `/dashboard` route
- add login and signup forms
- inject auth provider into layout
- update landing page header with dynamic auth links

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d3c1afe88832aa62eb8c7c0d8ef4c